### PR TITLE
bugfix: fix wrong import and use correct EmptyDataException reference

### DIFF
--- a/src/main/kotlin/logic/exception/FoodMoodException.kt
+++ b/src/main/kotlin/logic/exception/FoodMoodException.kt
@@ -7,6 +7,7 @@ sealed class FoodMoodException() : Exception() {
         data object EmptyMealName : Validation()
         data object NotFoundMealName: Validation()
         data object NotFoundCountryName: Validation()
+        data object EmptyDataException : Validation()
 
 
 

--- a/src/main/kotlin/logic/usecase/GetFastHealthyMealsUseCase.kt
+++ b/src/main/kotlin/logic/usecase/GetFastHealthyMealsUseCase.kt
@@ -1,8 +1,7 @@
 package logic
 
+import logic.exception.FoodMoodException
 import logic.models.Meal
-import org.example.logic.EmptyDataException
-
 class GetFastHealthyMealsUseCase(
     private val mealsRepository: MealsRepository
 ) {
@@ -10,9 +9,9 @@ class GetFastHealthyMealsUseCase(
     fun getFastHealthMeals(): List<Meal> {
         val allMeals = mealsRepository.getAllMeals()
         val validMeals = getValidMeals(allMeals)
-        if (validMeals.isEmpty()) throw EmptyDataException()
+        if (validMeals.isEmpty()) throw FoodMoodException.Validation.EmptyDataException
         val healthyMeals = filterHealthyMeals(validMeals)
-        if (healthyMeals.isEmpty()) throw EmptyDataException()
+        if (healthyMeals.isEmpty()) throw FoodMoodException.Validation.EmptyDataException
 
         return healthyMeals
     }


### PR DESCRIPTION
### Summary
This pull request fixes the incorrect usage of `EmptyDataException` by:

- Removing the invalid import `org.example.logic.EmptyDataException`.
- Replacing it with the proper reference `FoodMoodException.Validation.EmptyDataException`.

### Motivation
The previous import caused compilation errors due to a non-existent or outdated package path. This refactor improves code correctness and aligns exception handling with the sealed class structure.

### Changes
- ✅ Removed wrong import.
- ✅ Updated `throw` statement to use the qualified path.

### Testing
- [ ] Unit tests passed
- [ ] App compiles without errors
- [ ] Feature behaves as expected

### Related Issue / Task
- Resolves: #21  (if applicable)
