### PR TITLE
Test Coverage For Seafood Meals by Protein Use Case

### DIFF
--- a/src/main/kotlin/logic/usecase/GetSeafoodMealsByProteinUseCase.kt
+++ b/src/main/kotlin/logic/usecase/GetSeafoodMealsByProteinUseCase.kt
@@ -4,12 +4,11 @@ import logic.MealsRepository
 import logic.exception.FoodMoodException
 import logic.models.Meal
 
-
 class GetSeafoodMealsByProteinUseCase(
     private val mealsRepository: MealsRepository
 ) {
 
-    fun getSeafoodMealsByProteinUseCase(): List<Meal> {
+    fun getSeafoodMealsSortedByProtein(): List<Meal> {
         val allMeals = mealsRepository.getAllMeals()
         val validMeals = getValidMeals(allMeals).ifEmpty { throw FoodMoodException.Validation.EmptyDataException }
         val seafoodMeals =

--- a/src/main/kotlin/presentation/uiController/SeafoodMealsUIController.kt
+++ b/src/main/kotlin/presentation/uiController/SeafoodMealsUIController.kt
@@ -9,7 +9,7 @@ class SeafoodMealsSuccessUIController(private val getSeafoodMealsByProteinUseCas
     BaseUIController {
     override fun execute() {
         tryToExecute(
-            action = { getSeafoodMealsByProteinUseCase.getSeafoodMealsByProteinUseCase() },
+            action = { getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein() },
             onSuccess = ::onGetSeafoodMealsSuccess
         )
     }

--- a/src/test/kotlin/logic/helpers/SeafoodMealTestFactory.kt
+++ b/src/test/kotlin/logic/helpers/SeafoodMealTestFactory.kt
@@ -1,0 +1,30 @@
+package logic.helpers
+import logic.models.Meal
+import logic.models.Nutrition
+
+object SeafoodMealTestFactory {
+
+    private const val FISH_TAG = "seafood"
+
+    private val defaultNutrition = Nutrition(
+        totalFat = null,
+        saturatedFat = null,
+        carbohydrates = null,
+        calories = null,
+        sugar = null,
+        sodium = null,
+        protein = null,
+    )
+
+    fun createSeafoodMeal(name: String? = null, protein: Double? = null): Meal {
+        return createMeal(
+            name = name,
+            nutrition = defaultNutrition.copy(protein = protein),
+            tags = listOf(FISH_TAG)
+        )
+    }
+
+    val validTunaMeal = createSeafoodMeal(name = "Tuna", protein = 15.0)
+    val validShrimpMeal = createSeafoodMeal(name = "Shrimp", protein = 20.0)
+    val validSalmonMeal = createSeafoodMeal(name = "Salmon", protein = 25.0)
+}

--- a/src/test/kotlin/logic/usecase/GetSeafoodMealsByProteinUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecase/GetSeafoodMealsByProteinUseCaseTest.kt
@@ -1,0 +1,99 @@
+package logic.usecase
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import logic.MealsRepository
+import logic.exception.FoodMoodException
+import logic.helpers.SeafoodMealTestFactory.createSeafoodMeal
+import logic.helpers.SeafoodMealTestFactory.validSalmonMeal
+import logic.helpers.SeafoodMealTestFactory.validShrimpMeal
+import logic.helpers.createMeal
+import logic.helpers.SeafoodMealTestFactory.validTunaMeal
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GetSeafoodMealsByProteinUseCaseTest {
+    private lateinit var mealsRepository: MealsRepository
+    private lateinit var getSeafoodMealsByProteinUseCase: GetSeafoodMealsByProteinUseCase
+
+    @BeforeEach
+    fun setup() {
+        mealsRepository = mockk(relaxed = true)
+        getSeafoodMealsByProteinUseCase = GetSeafoodMealsByProteinUseCase(mealsRepository)
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should return all meals when all meals have non-null name and protein`() {
+        //Given
+        val meals = listOf(validSalmonMeal, validTunaMeal)
+
+        every { mealsRepository.getAllMeals() } returns meals
+
+        //When & Then
+        assertThat(getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein()).containsExactlyElementsIn(meals)
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should throw empty data exception when repository given empty list`() {
+        //Given
+        every { mealsRepository.getAllMeals() } returns emptyList()
+
+        //When & Then
+        assertThrows<FoodMoodException.Validation.EmptyDataException> { getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein() }
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should throw empty data exception when all meals have null nutrition`() {
+        //Given
+        every { mealsRepository.getAllMeals() } returns listOf(createMeal(), createMeal())
+
+        //When & Then
+        assertThrows<FoodMoodException.Validation.EmptyDataException> { getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein() }
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should throw empty data exception when all meals have null protein`() {
+        //Given
+        every { mealsRepository.getAllMeals() } returns listOf(createSeafoodMeal(), createSeafoodMeal())
+
+        //When & Then
+        assertThrows<FoodMoodException.Validation.EmptyDataException> { getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein() }
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should throw empty data exception when all meals have null name`() {
+        //Given
+        every { mealsRepository.getAllMeals() } returns listOf(createMeal(), createMeal())
+
+        //When & Then
+        assertThrows<FoodMoodException.Validation.EmptyDataException> { getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein() }
+    }
+
+    @Test
+    fun `getValidMeals should return only valid meals when some meals have null name or protein`() {
+        // Given
+        val meals = listOf(validSalmonMeal, createSeafoodMeal(protein = 10.0), createSeafoodMeal(name = "Crab"))
+
+        every { mealsRepository.getAllMeals() } returns meals
+
+        //When & Then
+        assertThat(getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein()).containsExactly(validSalmonMeal)
+
+    }
+
+    @Test
+    fun `getSeafoodMealsSortedByProtein should return correct sorted seafood meals by descending protein when all meals are valid`() {
+        // Given
+        val meals = listOf(validTunaMeal, validShrimpMeal, validSalmonMeal)
+
+        every { mealsRepository.getAllMeals() } returns meals
+
+        // When & Then
+        val sortedSeafoodMeals = listOf(validSalmonMeal, validShrimpMeal, validTunaMeal)
+        assertThat(getSeafoodMealsByProteinUseCase.getSeafoodMealsSortedByProtein())
+            .containsExactlyElementsIn(sortedSeafoodMeals)
+            .inOrder()
+    }
+}


### PR DESCRIPTION
This PR includes:

### 1. Add `GetSeafoodMealsByProteinUseCaseTest`
The tests cover various scenarios to ensure robustness and correct functionality, including:

- Returning all valid seafood meals with `non-null` name and protein.
- Sorting meals correctly by descending `protein `content.
- Handling edge cases where meals are missing essential data (e.g., `null name` or `protein`).
- Throwing appropriate `exceptions `when the repository returns an `empty list` or `invalid data`.

### 2. Add `SeafoodMealTestFactory `
- Provides helper method `createSeafoodMeal` for generating mock Meal instances
- Includes predefined `valid seafood meals` for use in test scenarios